### PR TITLE
5.3.1 commit

### DIFF
--- a/app/views/company-filed-not-required.html
+++ b/app/views/company-filed-not-required.html
@@ -27,7 +27,7 @@
 
       <p>The accounts and confirmation statement for BAD NEWS LIMITED have been filed and are up to date. This service is for companies with overdue filings.</p>
       <p>If COMPANY NAME is not required, you should
-        <a href="http://resources.companieshouse.gov.uk/close-a-company/index.html">close the company</a>
+        <a href="https://www.gov.uk/topic/company-registration-filing/closing-company">close the company</a>
         so that it is removed from the register.
 
       </div>

--- a/app/views/company-filed.html
+++ b/app/views/company-filed.html
@@ -26,44 +26,14 @@
       <h1 class="govuk-heading-xl">You cannot use this service</h1>
 
       <p>The accounts and confirmation statement for BAD NEWS LIMITED have been filed and are up to date. This service is for companies with overdue filings.</p>
-      <p>You do not need to let us know that the company is still required.</p>
-
-      {% set detailsText %}
-      <h2 class="govuk-heading-m">By email</h2>
-      <p class="govuk-body">enquiries@companieshouse.gov.uk</p>
-      <h2 class="govuk-heading-m">By post</h2>
-      <h3 class="govuk-heading-s">England and Wales</h3>
-      <p class="govuk-body">
-        Companies House<br/>
-        PO Box 710<br/>
-        Crown Way<br/>
-        CF14 3UZ
-      </p>
-      <h3 class="govuk-heading-s">Scotland</h3>
-      <p class="govuk-body">
-        Companies House<br/>
-        Fourth Floor<br/>
-        Edinburgh Quay 2<br/>
-        139 Fountainbridge<br/>
-        Edinburgh<br/>
-        EH3 9FF
-      </p>
-      <h3 class="govuk-heading-s">Northern Ireland</h3>
-      <p class="govuk-body">
-        Companies House<br/>
-        2nd Floor<br/>
-        The Linenhall<br/>
-        32-38 Linenhall Street<br/>
-        Belfast<br/>
-        BT2 8BG<br/>
-      </p>
-
-      {% endset %}
-
-      {{ govukDetails({
-        summaryText: "Contact us if you need to give more information or you want to talk to someone about reasonable adjustments.",
-        html: detailsText
-      }) }}
+      <p>If you're unable to meet your filing deadline, you can
+        <a href="https://beta.companieshouse.gov.uk/extensions">apply for an extension</a>.</p>
+      <p>If BAD NEWS LIMITED is not required, you should
+        <a href="https://www.gov.uk/topic/company-registration-filing/closing-company">close the company</a>
+        so that it is removed from the register.
+        <p>
+          <a href="https://www.gov.uk/government/organisations/companies-house/about/access-and-opening#cdf-addrs">Contact us</a>
+          if you need to give us information about exceptional circumstances that could mean you need reasonable adjustments.</p>
+      </div>
     </div>
-  </div>
-{% endblock %}
+  {% endblock %}

--- a/app/views/confirmation.html
+++ b/app/views/confirmation.html
@@ -33,8 +33,7 @@
       {% if scenario.company.PTFRequested !== 'yes' %}
         <p class="govuk-body-l">
           We've sent a confirmation email to
-          <span class="govuk-body-l govuk-!-font-weight-bold">{{ email }}</span>
-          which contains your reference number.
+          <span class="govuk-body-l govuk-!-font-weight-bold">{{ email }}</span>.
         </p>
       {% else %}
         <p class="govuk-body-l">

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -79,7 +79,7 @@
           },
           {
             href: "/",
-            text: "Prototype version 5.2.2"
+            text: "Prototype version 5.3.1"
           }
         ]
       }

--- a/app/views/no-officers.html
+++ b/app/views/no-officers.html
@@ -6,7 +6,12 @@
 {% block pageTitle %}
   You cannot use this service
 {% endblock %}
-
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "continue-trading"
+  }) }}
+{% endblock %}
 {% block content %}
 
   <div class="govuk-grid-row">
@@ -22,44 +27,10 @@
         <a href="https://www.gov.uk/government/publications/appoint-a-director-ap01">appoint a director</a>
         online.</p>
 
-      {% set detailsText %}
-      <h2 class="govuk-heading-m">By email</h2>
-      <p class="govuk-body">enquiries@companieshouse.gov.uk</p>
-      <h2 class="govuk-heading-m">By post</h2>
-      <h3 class="govuk-heading-s">England and Wales</h3>
-      <p class="govuk-body">
-        Companies House<br/>
-        PO Box 710<br/>
-        Crown Way<br/>
-        CF14 3UZ
-      </p>
-      <h3 class="govuk-heading-s">Scotland</h3>
-      <p class="govuk-body">
-        Companies House<br/>
-        Fourth Floor<br/>
-        Edinburgh Quay 2<br/>
-        139 Fountainbridge<br/>
-        Edinburgh<br/>
-        EH3 9FF
-      </p>
-      <h3 class="govuk-heading-s">Northern Ireland</h3>
-      <p class="govuk-body">
-        Companies House<br/>
-        2nd Floor<br/>
-        The Linenhall<br/>
-        32-38 Linenhall Street<br/>
-        Belfast<br/>
-        BT2 8BG<br/>
-      </p>
-
-      {% endset %}
-
-      {{ govukDetails({
-        summaryText: "Contact us if you need to give more information or you want to talk to someone about reasonable adjustments.",
-        html: detailsText
-      }) }}
-
-      <p class="govuk-body">
+      <p>
+        <a href="https://www.gov.uk/government/organisations/companies-house/about/access-and-opening#cdf-addrs">Contact us</a>
+        if you need to give us information about exceptional circumstances that could mean you need reasonable adjustments.</p>
+      <p class="govuk-body no-print">
         <a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html" class="govuk-link">What did you think of this service?</a>
         (takes 30 seconds)
       </p>

--- a/app/views/not-required.html
+++ b/app/views/not-required.html
@@ -30,12 +30,11 @@
       the penalty will increase over time. You should file as soon as possible. {% endif %} </p> -->
       <p class="govuk-body-l">
         We've sent a confirmation email to
-        <span class="govuk-body-l govuk-!-font-weight-bold">{{ email }}</span>
-        which contains your reference number.
+        <span class="govuk-body-l govuk-!-font-weight-bold">{{ email }}</span>.
       </p>
       <h2 class="govuk-heading-m">What happens next</h2>
       <p>You should
-        <a href="http://resources.companieshouse.gov.uk/close-a-company/index.html">close the company</a>
+        <a href="https://www.gov.uk/topic/company-registration-filing/closing-company">close the company</a>
         so that it is removed from the register. When you have closed the company, we will no longer pursue the overdue
         {{ scenario.company.reason }}.</p>
       <p>If you do not close the company and do not file your overdue

--- a/app/views/persistently-late.html
+++ b/app/views/persistently-late.html
@@ -6,7 +6,12 @@
 {% block pageTitle %}
   You cannot use this service
 {% endblock %}
-
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "continue-trading"
+  }) }}
+{% endblock %}
 {% block content %}
 
   <div class="govuk-grid-row">
@@ -16,46 +21,11 @@
 
       <p>The company
         {{scenario.company.name}}
-        has a history of late filing. You will need to contact us to tell us your company is still required.</p>
+        has a history of late filing. You will need to
+        <a href="https://www.gov.uk/government/organisations/companies-house/about/access-and-opening#cdf-addrs">contact us</a>
+        to tell us your company is still required.</p>
 
-      {% set detailsText %}
-      <h2 class="govuk-heading-m">By email</h2>
-      <p class="govuk-body">enquiries@companieshouse.gov.uk</p>
-      <h2 class="govuk-heading-m">By post</h2>
-      <h3 class="govuk-heading-s">England and Wales</h3>
-      <p class="govuk-body">
-        Companies House<br/>
-        PO Box 710<br/>
-        Crown Way<br/>
-        CF14 3UZ
-      </p>
-      <h3 class="govuk-heading-s">Scotland</h3>
-      <p class="govuk-body">
-        Companies House<br/>
-        Fourth Floor<br/>
-        Edinburgh Quay 2<br/>
-        139 Fountainbridge<br/>
-        Edinburgh<br/>
-        EH3 9FF
-      </p>
-      <h3 class="govuk-heading-s">Northern Ireland</h3>
-      <p class="govuk-body">
-        Companies House<br/>
-        2nd Floor<br/>
-        The Linenhall<br/>
-        32-38 Linenhall Street<br/>
-        Belfast<br/>
-        BT2 8BG<br/>
-      </p>
-
-      {% endset %}
-
-      {{ govukDetails({
-          summaryText: "Contact us",
-          html: detailsText
-        }) }}
-
-      <p class="govuk-body">
+      <p class="govuk-body no-print">
         <a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html" class="govuk-link">What did you think of this service?</a>
         (takes 30 seconds)
       </p>

--- a/app/views/prosecution.html
+++ b/app/views/prosecution.html
@@ -7,6 +7,13 @@
   You cannot use this service
 {% endblock %}
 
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "continue-trading"
+  }) }}
+{% endblock %}
+
 {% block content %}
 
   <div class="govuk-grid-row">
@@ -20,17 +27,34 @@
       {% endif %}
       {% endset %}
 
+      {% set csOnlyHTML %}
+      {% if scenario.company.reason == 'Limited Liability Partnership' %}
+        designated member
+      {% else %}
+        company director
+      {% endif %}
+      {% endset %}
+
+      {% set grammarHTML %}
+      {% if scenario.company.reason === 'confirmation statement' %}
+        is
+      {% else %}
+        are
+      {% endif %}
+      {% endset %}
+
       <h1 class="govuk-heading-xl">You cannot use this service</h1>
 
-      <p>The company
-        {{scenario.company.name}}
-        is already late filing their
-        {{scenario.company.reason}}. The company must now
+      <p>Too much time has elapsed since the
+        {{scenario.company.reason}}
+        filing deadline for
+        {{scenario.company.name}}. The company must now
         <a href="https://www.gov.uk/running-a-limited-company">file its overdue
           {{scenario.company.reason}}</a>.</p>
       <p>The company directors will receive a letter, if they haven’t already, to warn them that the company could be prosecuted if the
         {{scenario.company.reason}}
-        are not filed.</p>
+        {{ grammarHTML }}
+        not filed.</p>
       {% if scenario.company.reason !== 'confirmation statement' %}
         <p>The company will receive an automatic
           <a href="https://www.gov.uk/annual-accounts/penalties-for-late-filing">late filing penalty</a>
@@ -38,42 +62,9 @@
           late in consecutive years, the penalty will double for that year’s accounts.</p>
       {% else %}
       {% endif %}
-      {% set detailsText %}
-      <h2 class="govuk-heading-m">By email</h2>
-      <p class="govuk-body">enquiries@companieshouse.gov.uk</p>
-      <h2 class="govuk-heading-m">By post</h2>
-      <h3 class="govuk-heading-s">England and Wales</h3>
-      <p class="govuk-body">
-        Companies House<br/>
-        PO Box 710<br/>
-        Crown Way<br/>
-        CF14 3UZ
-      </p>
-      <h3 class="govuk-heading-s">Scotland</h3>
-      <p class="govuk-body">
-        Companies House<br/>
-        Fourth Floor<br/>
-        Edinburgh Quay 2<br/>
-        139 Fountainbridge<br/>
-        Edinburgh<br/>
-        EH3 9FF
-      </p>
-      <h3 class="govuk-heading-s">Northern Ireland</h3>
-      <p class="govuk-body">
-        Companies House<br/>
-        2nd Floor<br/>
-        The Linenhall<br/>
-        32-38 Linenhall Street<br/>
-        Belfast<br/>
-        BT2 8BG<br/>
-      </p>
-
-      {% endset %}
-
-      {{ govukDetails({
-        summaryText: "Contact us if you need to give more information or you want to talk to someone about reasonable adjustments.",
-        html: detailsText
-      }) }}
+      <p>
+        <a href="https://www.gov.uk/government/organisations/companies-house/about/access-and-opening#cdf-addrs">Contact us</a>
+        if you need to give us information about exceptional circumstances that could mean you need reasonable adjustments.</p>
       <p class="govuk-body">
         <a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html" class="govuk-link">What did you think of this service?</a>
         (takes 30 seconds)

--- a/app/views/repeat-application.html
+++ b/app/views/repeat-application.html
@@ -6,39 +6,13 @@
 {% block pageTitle %}
   You cannot use this service
 {% endblock %}
-
+{% block backLink %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "continue-trading"
+  }) }}
+{% endblock %}
 {% block content %}
-
-  {% set detailsTextHTML %}
-  <h2 class="govuk-heading-m">By email</h2>
-  <p class="govuk-body">enquiries@companieshouse.gov.uk</p>
-  <h2 class="govuk-heading-m">By post</h2>
-  <h3 class="govuk-heading-s">England and Wales</h3>
-  <p class="govuk-body">
-    Companies House<br/>
-    PO Box 710<br/>
-    Crown Way<br/>
-    CF14 3UZ
-  </p>
-  <h3 class="govuk-heading-s">Scotland</h3>
-  <p class="govuk-body">
-    Companies House<br/>
-    Fourth Floor<br/>
-    Edinburgh Quay 2<br/>
-    139 Fountainbridge<br/>
-    Edinburgh<br/>
-    EH3 9FF
-  </p>
-  <h3 class="govuk-heading-s">Northern Ireland</h3>
-  <p class="govuk-body">
-    Companies House<br/>
-    2nd Floor<br/>
-    The Linenhall<br/>
-    32-38 Linenhall Street<br/>
-    Belfast<br/>
-    BT2 8BG<br/>
-  </p>
-  {% endset %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -47,17 +21,15 @@
 
       <p>We've already been told that BAD NEWS LIMITED is still required.</p>
 
-      <p class="govuk-body">The company must now <a href="https://www.gov.uk/running-a-limited-company">file its overdue accounts or confirmation statement</a>.</p>
-  <ul class="govuk-list govuk-list--bullet">
-  </ul>
+      <p class="govuk-body">The company must now
+        <a href="https://www.gov.uk/running-a-limited-company">file its overdue accounts or confirmation statement</a>.</p>
+      <ul class="govuk-list govuk-list--bullet"></ul>
 
-        <P>If the company's accounts are overdue, it will receive a late filing penalty that increases until it files. If the company's confirmation statement is overdue, it will not receive a penalty.</p>
-      {{ govukDetails({
-        summaryText: "Contact us if you need to give more information or you want to talk to someone about reasonable adjustments.",
-        html: detailsTextHTML
-      }) }}
-
-      <p class="govuk-body">
+      <p>If the company's accounts are overdue, it will receive a late filing penalty that increases until it files. If the company's confirmation statement is overdue, it will not receive a penalty.</p>
+      <p>
+        <a href="https://www.gov.uk/government/organisations/companies-house/about/access-and-opening#cdf-addrs">Contact us</a>
+        if you need to give us information about exceptional circumstances that could mean you need reasonable adjustments.</p>
+      <p class="govuk-body no-print">
         <a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html" class="govuk-link">What did you think of this service?</a>
         (takes 30 seconds)
       </p>

--- a/app/views/start.html
+++ b/app/views/start.html
@@ -19,23 +19,20 @@
         {% endif %}
       </h1>
       <p class="govuk-body-l">Use this service to tell us if you still require a company that is late filing its accounts or confirmation statement.</p>
-      <p>This will stop us from closing the company if we think it is not required.</p>
-      <p>If the company's accounts are overdue, it will receive a late filing penalty that increases until it files. If the company's confirmation statement is overdue, it will not receive a penalty.</p>
-      <p>If the company is not required, you should
-        <a href="http://resources.companieshouse.gov.uk/close-a-company/index.html">close the company</a>.</p>
+      <p>This will stop us from closing the company if we think it is not required. If it is no longer required, you should
+        <a href="https://www.gov.uk/topic/company-registration-filing/closing-company">close the company</a>.</p>
+      <p>If the company's accounts are overdue, it will receive a
+        <a href="https://www.gov.uk/government/publications/life-of-a-company-annual-requirements/life-of-a-company-part-1-accounts#penalties-for-failing-to-file-accounts" target="_blank">late filing penalty</a>
+        that increases until it files. If the company's confirmation statement is overdue, it will not receive a penalty.</p>
 
       {{ govukWarningText({
         text: "Not filing for a company is a criminal offence. The directors of the company risk prosecution and company assets may be seized. ",
         iconFallbackText: "Warning"
       }) }}
       <h2 class="govuk-heading-m">Before you start</h2>
-      <p>
-        You should
-        <a href="https://www.gov.uk/government/publications/life-of-a-company-annual-requirements/life-of-a-company-part-1-accounts#penalties-for-failing-to-file-accounts" target="_blank">read the guidance on late filing penalties</a>.
-      </p>
+      <p></p>
       <p>You'll need:
         <ul class="govuk-list govuk-list--bullet">
-          <li>an email address</li>
           <li>the company number</li>
           <li>the company authentication code for online filing</li>
         </ul>

--- a/app/views/still-required.html
+++ b/app/views/still-required.html
@@ -20,8 +20,8 @@
   {% set warningHTML %}
   Failure to file confirmation statements or accounts is a criminal offence and the
   {{ llpHTML }}
-  of the company can be fined in criminal court. Information about the consequences of not filing can be
-  <a href="https://www.gov.uk/government/publications/late-filing-penalties/late-filing-penalties#late-filing-penalty-fees">found in our guidance</a>.
+  of the company can be fined in criminal court.
+  <a href="https://www.gov.uk/government/publications/late-filing-penalties/late-filing-penalties#late-filing-penalty-fees">Read the guidance for information about the consequences of not filing</a>.
   {% endset %}
 
   <div class="govuk-grid-row">
@@ -48,8 +48,7 @@
       {% if scenario.company.PTFRequested !== 'yes' %}
         <p class="govuk-body-l">
           We've sent a confirmation email to
-          <span class="govuk-body-l govuk-!-font-weight-bold">{{ email }}</span>
-          which contains your reference number.
+          <span class="govuk-body-l govuk-!-font-weight-bold">{{ email }}</span>.
         </p>
       {% else %}
         <p class="govuk-body-l">
@@ -69,28 +68,30 @@
         will be kept on the register. This means we will no longer close the company, but it must file its
         {{ scenario.company.reason }}
         to stay on the register.</p>
-      {% if scenario.company.reason !== 'confirmation statement' %}
-        <p>The company will receive a
-          <a href="https://www.gov.uk/annual-accounts/penalties-for-late-filing">late filing penalty</a>
-          as soon as the accounts are filed and accepted because they are already late. The penalty will increase over time until the accounts are filed and applies to all companies, no matter what size or type of business. If the company's accounts are filed
-          late in consecutive years, the penalty will double for that year's accounts. The original filing deadline has not been changed or extended.</p>
-      {% endif %}
       <p>If
         {{ scenario.company.name }}
         has not filed by
         {{ scenario.company.newDeadline }}, we may prosecute the{{ llpHTML }}
-        of the company.</p>
+        of the company. The original filing deadline has not been changed or extended.</p>
       <p>
-        <a href="https://www.gov.uk/government/organisations/companies-house/about/access-and-opening#cdf-addrs">Contact us</a>
-        if you need to give more information or you want to talk to someone about reasonable adjustments.</p>
-      {{ govukWarningText({
+        {% if scenario.company.reason !== 'confirmation statement' %}
+          <p>The company will receive a
+            <a href="https://www.gov.uk/annual-accounts/penalties-for-late-filing">late filing penalty</a>
+            as soon as the accounts are filed and accepted because they are already late. The penalty will increase over time until the accounts are filed and applies to all companies, no matter what size or type of business. If the company's accounts are filed
+            late in consecutive years, the penalty will double for that year's accounts.</p>
+        {% endif %}
+
+        <p>
+          <a href="https://www.gov.uk/government/organisations/companies-house/about/access-and-opening#cdf-addrs">Contact us</a>
+          if you need to give us information about exceptional circumstances that could mean you need reasonable adjustments.</p>
+        {{ govukWarningText({
         html: warningHTML,
         iconFallbackText: "Warning" }) }}
-      <p class="govuk-body no-print">
-        <a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html" class="govuk-link">What did you think of this service?</a>
-        (takes 30 seconds)
-      </p>
+        <p class="govuk-body no-print">
+          <a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html" class="govuk-link">What did you think of this service?</a>
+          (takes 30 seconds)
+        </p>
+      </div>
     </div>
-  </div>
 
-{% endblock %}
+  {% endblock %}


### PR DESCRIPTION
Still required page
- remove "which contains your reference number" from email sentence after confirmation banner.
-content around the guidance link has changed
-"original filing deadline has not been changed or extended" has moved.
-contact us paragraph has changed
Not required page
- remove "which contains your reference number" from email sentence after confirmation banner.
- change link to close a company
Prosecution page
- first paragraph has been changed.
-Contact info has changed.
Start page
-All the content has moved around
-close a company link has been updated
-email address has been removed
Company filed stop page
-content changed
No officers stop page
-contact us changes
-added back link
Persistently late stop page
-contact us changes
-added back link
repeat application stop page
-contact us changes
-added back link